### PR TITLE
Add override for searching for discoverable private key files

### DIFF
--- a/fs_task_queue/plugins/ssh.py
+++ b/fs_task_queue/plugins/ssh.py
@@ -8,6 +8,7 @@ import paramiko
 from paramiko.client import SSHClient
 
 from fs_task_queue.core import Queue, JSONSerializer, DummyLock, Job, JobStatus
+from fs_task_queue.utils import eval_boolean_env_var
 
 
 class SSHJob(Job):

--- a/fs_task_queue/plugins/ssh.py
+++ b/fs_task_queue/plugins/ssh.py
@@ -75,6 +75,8 @@ class SSHQueue(Queue):
             "password": p.password,
             "key_filename": os.environ.get("PARAMIKO_SSH_KEYFILE"),
             "passphrase": os.environ.get("PARAMIKO_SSH_PASSPHRASE"),
+            "allow_agent": eval_boolean_env_var("PARAMIKO_SSH_ALLOW_AGENT", True),
+            "look_for_keys": eval_boolean_env_var("PARAMIKO_SSH_LOOK_FOR_KEYS", True),
             "path": p.path,
         }
 
@@ -85,6 +87,8 @@ class SSHQueue(Queue):
             port=params["port"],
             username=params["username"],
             password=params["password"],
+            look_for_keys=params["look_for_keys"],
+            allow_agent=params["allow_agent"],
             key_filename=params["key_filename"],
             passphrase=params["passphrase"],
         )

--- a/fs_task_queue/utils.py
+++ b/fs_task_queue/utils.py
@@ -1,5 +1,6 @@
 import contextlib
 import time
+import os
 
 
 @contextlib.contextmanager
@@ -8,3 +9,30 @@ def timer(logger, prefix: str):
     logger.info(f"Starting {prefix}")
     yield
     logger.info(f"Finished {prefix} took {time.time() - start_time:.2f} [s]")
+
+def eval_boolean_env_var(variable:str, default:bool):
+    """
+    Attempt to evaluate a boolean environment variable according to its value.
+
+    Args:
+        variable (str): Name of the environment variable to evaluate.
+        default (bool): Default value to return if the variable is not found.
+
+    Raises:
+        ValueError: If the value of the environment variable is not a valid boolean.
+
+    Returns:
+        bool: The value of the environment variable or the default.
+    """
+
+    value = os.getenv(variable)
+
+    if value:
+        if value.lower() in ['true', '1']:
+            return True
+        elif value.lower() in ['false', '0']:
+            return False
+        else:
+            raise ValueError(f"Invalid value for {variable}")
+    else:
+        return default

--- a/fs_task_queue/utils.py
+++ b/fs_task_queue/utils.py
@@ -10,7 +10,8 @@ def timer(logger, prefix: str):
     yield
     logger.info(f"Finished {prefix} took {time.time() - start_time:.2f} [s]")
 
-def eval_boolean_env_var(variable:str, default:bool):
+
+def eval_boolean_env_var(variable: str, default: bool):
     """
     Attempt to evaluate a boolean environment variable according to its value.
 
@@ -28,9 +29,9 @@ def eval_boolean_env_var(variable:str, default:bool):
     value = os.getenv(variable)
 
     if value:
-        if value.lower() in ['true', '1']:
+        if value.lower() in ["true", "1"]:
             return True
-        elif value.lower() in ['false', '0']:
+        elif value.lower() in ["false", "0"]:
             return False
         else:
             raise ValueError(f"Invalid value for {variable}")


### PR DESCRIPTION
It seems that using only the 
```
        self._ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
```
It might cause some issues when re-executing the code with different hosts, as the default ssh-agent might try to inspect the available host keys (private/public), which in some cases might get using the wrong pair for connection.

According to [Paramiko docs](https://docs.paramiko.org/en/stable/api/client.html#paramiko.client.SSHClient.connect):


> Authentication is attempted in the following order of priority:
> 
> - The pkey or key_filename passed in (if any)
>   - key_filename may contain OpenSSH public certificate paths as well as regular private-key paths; when files ending in -cert.pub are found, they are assumed to match a private key, and both components will be loaded. (The private key itself does not need to be listed in key_filename for this to occur - just the certificate.)
> - Any key we can find through an SSH agent
> - Any “id_rsa”, “id_dsa” or “id_ecdsa” key discoverable in ~/.ssh/
>   - When OpenSSH-style public certificates exist that match an existing such private key (so e.g. one has id_rsa and id_rsa-cert.pub) the certificate will be loaded alongside the private key and used for authentication.
> - Plain username/password auth, if a password was given

Bellow, an example of such a situation is where paramiko/ssh-agent seems to disregard the public key created for `ssh://root:password@localhost:2222` and went directly to test all keys present in `/.ssh`.
```
INFO:paramiko.transport:Connected (version 2.0, client OpenSSH_8.9p1)
INFO:paramiko.transport:Authentication (publickey) failed.
ERROR:paramiko.transport:Exception (client): key cannot be used for signing
ERROR:paramiko.transport:Traceback (most recent call last):
ERROR:paramiko.transport:  File "/home/vcerutti/miniconda3/envs/hms-test/lib/python3.8/site-packages/paramiko/transport.py", line 2164, in run
ERROR:paramiko.transport:    handler(self.auth_handler, m)
ERROR:paramiko.transport:  File "/home/vcerutti/miniconda3/envs/hms-test/lib/python3.8/site-packages/paramiko/auth_handler.py", line 395, in _parse_service_accept
ERROR:paramiko.transport:    sig = self.private_key.sign_ssh_data(blob, algorithm)
ERROR:paramiko.transport:  File "/home/vcerutti/miniconda3/envs/hms-test/lib/python3.8/site-packages/paramiko/agent.py", line 436, in sign_ssh_data
ERROR:paramiko.transport:    raise SSHException("key cannot be used for signing")
ERROR:paramiko.transport:paramiko.ssh_exception.SSHException: key cannot be used for signing
ERROR:paramiko.transport:
Traceback (most recent call last):
  File "/home/vcerutti/miniconda3/envs/hms-test/bin/matriarch", line 8, in <module>
    sys.exit(main())
  File "/home/vcerutti/Quansight/harvard/hms22-image-analysis/matriarch/client/__main__.py", line 5, in main
    cli()
  File "/home/vcerutti/Quansight/harvard/hms22-image-analysis/matriarch/client/cli.py", line 20, in cli
    return handle_cli(args)
  File "/home/vcerutti/Quansight/harvard/hms22-image-analysis/matriarch/client/cli.py", line 36, in handle_cli
    queue = SSHQueue(args.queue_directory)
  File "/home/vcerutti/miniconda3/envs/hms-test/lib/python3.8/site-packages/fs_task_queue/plugins/ssh.py", line 57, in __init__
    directory = self._create_client(directory)
  File "/home/vcerutti/miniconda3/envs/hms-test/lib/python3.8/site-packages/fs_task_queue/plugins/ssh.py", line 87, in _create_client
    self._ssh_client.connect(
  File "/home/vcerutti/miniconda3/envs/hms-test/lib/python3.8/site-packages/paramiko/client.py", line 450, in connect
    self._auth(
  File "/home/vcerutti/miniconda3/envs/hms-test/lib/python3.8/site-packages/paramiko/client.py", line 781, in _auth
    raise saved_exception
  File "/home/vcerutti/miniconda3/envs/hms-test/lib/python3.8/site-packages/paramiko/client.py", line 768, in _auth
    self._transport.auth_password(username, password)
  File "/home/vcerutti/miniconda3/envs/hms-test/lib/python3.8/site-packages/paramiko/transport.py", line 1553, in auth_password
    raise SSHException("No existing session")
paramiko.ssh_exception.SSHException: No existing session
```

As user/creds are the last auth measure tested, it might be interesting having some way to disable the ssh-agent altogether to look for keys. According to the available settings fro `SSHClient.connect`, we can pass `allo_agent` and `look_for_keys` values. This PR adds such overriding capability